### PR TITLE
Styling fixes.

### DIFF
--- a/src/components/Drawer/drawer-content/drawer-content.scss
+++ b/src/components/Drawer/drawer-content/drawer-content.scss
@@ -1,5 +1,5 @@
 .dapp-sidebar {
-  height: 100vh;
+  min-height: 100%;
   min-width: 280px;
   display: flex;
   flex-direction: column;
@@ -18,7 +18,7 @@
 
     .wallet-link {
       margin: 10px;
-  
+
       p{
         color: #FFFFFF;
         font-family: Mono;
@@ -56,7 +56,7 @@
           display: flex;
           flex-direction: row;
           align-items: center;
-        
+
           p{
             font-weight: 500;
             font-size: 16px;
@@ -77,14 +77,6 @@
         }
       }
 
-      .button-dapp-menu.active {
-        .dapp-menu-item{
-          p{
-            text-decoration: none;
-          }
-        }
-      }
-
       .bond-discounts {
         text-align: left;
         padding-left: 52px;
@@ -96,13 +88,13 @@
           font-size: 12px;
           letter-spacing: 1px;
         }
-      
+
         a{
           margin-left: 0;
           margin-top: 20px;
           margin-bottom: 20px;
         }
-      
+
         p {
           font-family: Montserrat;
           font-size: 14px;
@@ -110,7 +102,7 @@
           color: #b5b9bb;
           font-feature-settings: "ss09", "ss11";
         }
-        
+
         .bond {
           display: block;
           padding: unset;
@@ -127,7 +119,7 @@
 
   .dapp-menu-doc-link{
     margin-top: auto;
-    
+
     a {
       display: flex;
       width: 100%;
@@ -172,14 +164,14 @@
 
 .MuiDrawer-root{
   .MuiPaper-root{
-    
+
     z-index: 7;
 
     @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {
       background: rgba(36, 39, 41, 0.1);
       backdrop-filter: blur(40px);
     }
-  
+
     /* slightly transparent fallback for Firefox (not supporting backdrop-filter) */
     @supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
       background: #181B1C;

--- a/src/components/Drawer/drawer-content/drawer-content.scss
+++ b/src/components/Drawer/drawer-content/drawer-content.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   background: rgba(0, 1, 40, 0.5);
   border-right: 1px solid #30363a;
+  overflow-y: auto;
 
   .branding-header {
     display: flex;
@@ -164,8 +165,8 @@
 
 .MuiDrawer-root{
   .MuiPaper-root{
-
     z-index: 7;
+    overflow-y: hidden;
 
     @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {
       background: rgba(36, 39, 41, 0.1);

--- a/src/components/Drawer/drawer-content/index.tsx
+++ b/src/components/Drawer/drawer-content/index.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useState } from "react";
 import { NavLink } from "react-router-dom";
 import Social from "./social";
 import StakeIcon from "../../../assets/icons/stake.svg";
@@ -16,26 +15,10 @@ import useBonds from "../../../hooks/bonds";
 import { Link } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import "./drawer-content.scss";
-import classnames from "classnames";
 
 function NavContent() {
-    const [isActive] = useState();
     const address = useAddress();
     const { bonds } = useBonds();
-
-    const checkPage = useCallback((location: any, page: string): boolean => {
-        const currentPath = location.pathname.replace("/", "");
-        if (currentPath.indexOf("dashboard") >= 0 && page === "dashboard") {
-            return true;
-        }
-        if (currentPath.indexOf("stake") >= 0 && page === "stake") {
-            return true;
-        }
-        if (currentPath.indexOf("mints") >= 0 && page === "mints") {
-            return true;
-        }
-        return false;
-    }, []);
 
     return (
         <div className="dapp-sidebar">
@@ -55,43 +38,21 @@ function NavContent() {
 
             <div className="dapp-menu-links">
                 <div className="dapp-nav">
-                    <Link
-                        component={NavLink}
-                        to="/dashboard"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "dashboard");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    <Link component={NavLink} to="/dashboard" className="button-dapp-menu">
                         <div className="dapp-menu-item">
                             <img alt="" src={DashboardIcon} />
                             <p>Dashboard</p>
                         </div>
                     </Link>
 
-                    <Link
-                        component={NavLink}
-                        to="/stake"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "stake");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    <Link component={NavLink} to="/stake" className="button-dapp-menu">
                         <div className="dapp-menu-item">
                             <img alt="" src={StakeIcon} />
                             <p>Stake</p>
                         </div>
                     </Link>
 
-                    <Link
-                        component={NavLink}
-                        id="bond-nav"
-                        to="/mints"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "mints");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    <Link component={NavLink} id="bond-nav" to="/mints" className="button-dapp-menu">
                         <div className="dapp-menu-item">
                             <img alt="" src={BondIcon} />
                             <p>Mint</p>
@@ -126,14 +87,7 @@ function NavContent() {
                         </div>
                     </Link>
 
-                    <Link
-                        component={NavLink}
-                        to="/snowglobe"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "snowglobe");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    <Link component={NavLink} to="/snowglobe" className="button-dapp-menu">
                         <div className="button-dapp-menu">
                             <div className="dapp-menu-item">
                                 <img alt="" src={Snowglobe} />
@@ -142,15 +96,7 @@ function NavContent() {
                         </div>
                     </Link>
 
-                    {/* <Link
-                        component={NavLink}
-                        id="bond-nav"
-                        to="#"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "mints");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    {/* <Link component={NavLink} id="bond-nav" to="#" className="button-dapp-menu">
                         <div className="dapp-menu-item">
                             <img alt="" src={BorrowIcon} />
                             <p>Borrow</p>
@@ -158,15 +104,7 @@ function NavContent() {
                         </div>
                     </Link> */}
 
-                    <Link
-                        component={NavLink}
-                        id="bond-nav"
-                        to="#"
-                        isActive={(match: any, location: any) => {
-                            return checkPage(location, "mints");
-                        }}
-                        className={classnames("button-dapp-menu", { active: isActive })}
-                    >
+                    <Link component={NavLink} id="bond-nav" to="#" className="button-dapp-menu">
                         <div className="dapp-menu-item">
                             <img alt="" src={ProIcon} />
                             <p>SB Pro</p>


### PR DESCRIPTION
- `.dapp-sidebar` is already in a `100vh` container, so setting the height to `100vh` caused there to be no background if there was overflow scrolling
- `.active` on `.button-dapp-menu` did not do anything because the `p` tag didn't have any text-decoration when inactive
- Prettier made me put all the Link props on one line