### PR TITLE
show/hide wrapped lines depending on wallet having wrapped tokens

### DIFF
--- a/src/locales/en/stake.json
+++ b/src/locales/en/stake.json
@@ -7,6 +7,7 @@
     "UnstakingStakedSB": "Unstaking sSB",
     "YourStakedBalance": "Your Staked Balance",
     "YourWrappedStakedBalance": "Your Wrapped Staked Balance",
+    "WrappedTokenEquivalent": "Your Wrapped sSB is equivalent to",
     "NextRewardAmount": "Next Reward Amount",
     "NextRewardYield": "Next Reward Yield",
     "ROIFiveDayRate": "$t(ROI) ($t(FiveDayRate))",

--- a/src/views/Stake/index.tsx
+++ b/src/views/Stake/index.tsx
@@ -298,11 +298,21 @@ function Stake() {
                                             <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{trimmedSSBBalance} sSB</>}</p>
                                         </div>
 
-                                        <div className="data-row">
-                                            <p className="data-row-name">{t("stake:YourWrappedStakedBalance")}</p>
-                                            <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{trimmedWrappedStakedSBBalance} wsSB</>}</p>
-                                        </div>
+                                        {Number(trimmedWrappedStakedSBBalance) > 0 && (
+                                            <div className="data-row">
+                                                <p className="data-row-name">{t("stake:YourWrappedStakedBalance")}</p>
+                                                <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{trimmedWrappedStakedSBBalance} wsSB</>}</p>
+                                            </div>
+                                        )}
 
+                                        {Number(trimmedWrappedStakedSBBalance) > 0 && (
+                                            <div className="data-row">
+                                                <p className="data-row-name">Your Wrapped sSB is equivalent to</p>
+                                                <p className="data-row-value">
+                                                    {isAppLoading ? <Skeleton width="80px" /> : <>({trim(Number(trimmedWrappedStakedSBBalance) * Number(currentIndex), 6)} sSB)</>}
+                                                </p>
+                                            </div>
+                                        )}
                                         <div className="data-row">
                                             <p className="data-row-name">{t("stake:NextRewardAmount")}</p>
                                             <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{nextRewardValue} SB</>}</p>
@@ -349,10 +359,12 @@ function Stake() {
                                                 <p className="data-row-value"> {isAppLoading ? <Skeleton width="80px" /> : <>{valueOfStakedBalance}</>}</p>
                                             </div>
 
-                                            <div className="data-row">
-                                                <p className="data-row-name">{t("stake:ValueOfYourWrappedStakedSB")}</p>
-                                                <p className="data-row-value"> {isAppLoading ? <Skeleton width="80px" /> : <>{valueOfWrappedStakedBalance}</>}</p>
-                                            </div>
+                                            {Number(trimmedWrappedStakedSBBalance) > 0 && (
+                                                <div className="data-row">
+                                                    <p className="data-row-name">{t("stake:ValueOfYourWrappedStakedSB")}</p>
+                                                    <p className="data-row-value"> {isAppLoading ? <Skeleton width="80px" /> : <>{valueOfWrappedStakedBalance}</>}</p>
+                                                </div>
+                                            )}
                                         </div>
                                     </div>
                                 </div>

--- a/src/views/Stake/index.tsx
+++ b/src/views/Stake/index.tsx
@@ -307,7 +307,7 @@ function Stake() {
 
                                         {Number(trimmedWrappedStakedSBBalance) > 0 && (
                                             <div className="data-row">
-                                                <p className="data-row-name">Your Wrapped sSB is equivalent to</p>
+                                                <p className="data-row-name">{t("stake:WrappedTokenEquivalent")}</p>
                                                 <p className="data-row-value">
                                                     {isAppLoading ? <Skeleton width="80px" /> : <>({trim(Number(trimmedWrappedStakedSBBalance) * Number(currentIndex), 6)} sSB)</>}
                                                 </p>


### PR DESCRIPTION
Some users grumbling about too many extra lines on Stake page.  I therefore wrapped show/hide logic around wsSB lines to test whether or not the wallet has any wrapped sSB tokens.