### PR TITLE
Track wsSB in Effective Next Reward Amount

### DIFF
--- a/src/locales/en/stake.json
+++ b/src/locales/en/stake.json
@@ -9,6 +9,7 @@
     "YourWrappedStakedBalance": "Your Wrapped Staked Balance",
     "WrappedTokenEquivalent": "Your Wrapped sSB is equivalent to",
     "NextRewardAmount": "Next Reward Amount",
+    "EffectiveNextRewardAmount": "Effective Next Reward Amount",
     "NextRewardYield": "Next Reward Yield",
     "ROIFiveDayRate": "$t(ROI) ($t(FiveDayRate))",
     "ValueOfYourSB": "Value of Your SB",
@@ -19,5 +20,6 @@
     "ApproveStaking": "Approve Staking",
     "ApproveUnstaking": "Approve Unstaking",
     "ApproveNote": "Note: The \"Approve\" transaction is only needed when staking/unstaking for the first time; subsequent staking/unstaking only requires you to perform the \"Stake\" or \"Unstake\" transaction.",
-    "ValueOfYourNextRewardAmount": "Value of Your Next Reward Amount"
+    "ValueOfYourNextRewardAmount": "Value of Your Next Reward Amount",
+    "ValueOfYourEffectiveNextRewardAmount": "Value of Your Effective Next Reward Amount"
 }

--- a/src/views/Stake/index.tsx
+++ b/src/views/Stake/index.tsx
@@ -105,6 +105,8 @@ function Stake() {
     const trimmedStakingAPY = trim(stakingAPY * 100, 1);
     const stakingRebasePercentage = trim(stakingRebase * 100, 4);
     const nextRewardValue = trim((Number(stakingRebasePercentage) / 100) * Number(trimmedSSBBalance), 6);
+    const wrappedTokenEquivalent = trim(Number(trimmedWrappedStakedSBBalance) * Number(currentIndex), 6);
+    const effectiveNextRewardValue = trim(Number(nextRewardValue + (Number(stakingRebasePercentage) / 100) * Number(wrappedTokenEquivalent)), 6);
     const valueOfSB = new Intl.NumberFormat("en-US", {
         style: "currency",
         currency: "USD",
@@ -137,6 +139,12 @@ function Stake() {
         maximumFractionDigits: 2,
         minimumFractionDigits: 2,
     }).format(Number(nextRewardValue) * app.marketPrice);
+    const valueOfYourEffectiveNextRewardAmount = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+    }).format(Number(effectiveNextRewardValue) * app.marketPrice);
 
     return (
         <div className="stake-view">
@@ -314,15 +322,20 @@ function Stake() {
                                         {Number(trimmedWrappedStakedSBBalance) > 0 && (
                                             <div className="data-row">
                                                 <p className="data-row-name">{t("stake:WrappedTokenEquivalent")}</p>
-                                                <p className="data-row-value">
-                                                    {isAppLoading ? <Skeleton width="80px" /> : <>({trim(Number(trimmedWrappedStakedSBBalance) * Number(currentIndex), 6)} sSB)</>}
-                                                </p>
+                                                <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>({wrappedTokenEquivalent} sSB)</>}</p>
                                             </div>
                                         )}
                                         <div className="data-row">
                                             <p className="data-row-name">{t("stake:NextRewardAmount")}</p>
                                             <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{nextRewardValue} SB</>}</p>
                                         </div>
+
+                                        {Number(trimmedWrappedStakedSBBalance) > 0 && (
+                                            <div className="data-row">
+                                                <p className="data-row-name">{t("stake:EffectiveNextRewardAmount")}</p>
+                                                <p className="data-row-value">{isAppLoading ? <Skeleton width="80px" /> : <>{effectiveNextRewardValue} SB</>}</p>
+                                            </div>
+                                        )}
 
                                         <div className="data-row">
                                             <p className="data-row-name">{t("stake:NextRewardYield")}</p>
@@ -368,6 +381,11 @@ function Stake() {
                                             <div className="data-row">
                                                 <p className="data-row-name">{t("stake:ValueOfYourNextRewardAmount")}</p>
                                                 <p className="data-row-value"> {isAppLoading ? <Skeleton width="80px" /> : <>{valueOfYourNextRewardAmount}</>}</p>
+                                            </div>
+
+                                            <div className="data-row">
+                                                <p className="data-row-name">{t("stake:ValueOfYourEffectiveNextRewardAmount")}</p>
+                                                <p className="data-row-value"> {isAppLoading ? <Skeleton width="80px" /> : <>{valueOfYourEffectiveNextRewardAmount}</>}</p>
                                             </div>
 
                                             {Number(trimmedWrappedStakedSBBalance) > 0 && (


### PR DESCRIPTION
Count wsSB in a new variable, Effective Next Reward Amount. It can improve UX by showing the effective amount of sSB you are getting (if you only have wsSB), instead of someone having to calculate it themselves with Next Reward Yield.

When there are wsSB tokens being tracked in that user's wallet, it could display a small icon that users can hover on or click to show an informational message about wsSB being tracked. 